### PR TITLE
invoke-assembly arg parsing quoted strings

### DIFF
--- a/Payload_Type/merlin/container/commands/invokeAssembly.go
+++ b/Payload_Type/merlin/container/commands/invokeAssembly.go
@@ -137,7 +137,13 @@ func invokeAssemblyCreateTasking(task *structs.PTTaskMessageAllData) (resp struc
 	}
 
 	if args != "" {
-		job.Args = append(job.Args, strings.Split(args, " ")...)
+		quoted := false
+		job.Args = append(job.Args, strings.FieldsFunc(args, func(r rune) bool {
+			if r == '"' {
+				quoted = !quoted
+			}
+			return !quoted && r == ' '
+		})...)
 	}
 
 	mythicJob, err := ConvertMerlinJobToMythicTask(job, jobs.MODULE)

--- a/agent_capabilities.json
+++ b/agent_capabilities.json
@@ -1,5 +1,5 @@
 {
-  "mythic_version": "3.6",
+  "mythic_version": "3.2",
   "agent_version": "2.2.0",
   "os": ["FreeBSD","macOS", "Linux", "OpenBSD","Solaris","Windows"],
   "c2": ["http"],


### PR DESCRIPTION
## Fixing invoke-assembly arg parsing
invoke-assembly didn't properly parse arguments when the arg was a string with a space, even if that arg was "quoted". Instead, it treated it as two separate args separated by the space char. 

I have a .net assembly that takes a path to a file on disk, and found that paths with spaces never worked. 

## The fix
Looks like several ways to fix it, won't claim to know what's best.. but this PR is one way to fix it. Based on the following google search https://stackoverflow.com/questions/47489745/splitting-a-string-at-space-except-inside-quotation-marks

## Testing
As an example, here is a screenshot of the issue, and an example .net assembly that shows what happened before this PR. 
 
![image](https://github.com/MythicAgents/merlin/assets/51980089/f5ac6e7d-8bf6-424d-b782-e31b7e2d23aa)
```
using System;
using System.Collections.Generic;
using System.Linq;
using System.Text;
using System.Threading.Tasks;

namespace StringExample
{
    internal class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine(" Number of Args passed to assembly : " + args.Length);
            var myString = args[0];
            Console.WriteLine(" Path that was passed in : " + myString );
            return;
            //var fileBytes = System.IO.File.ReadAllBytes(pathToFile);
        }
    }
}

```
Thanks!